### PR TITLE
Export component format placeholder. Fix #8

### DIFF
--- a/src/common/index.js
+++ b/src/common/index.js
@@ -1,0 +1,2 @@
+// Export component format placeholder
+// export { default as Resource } from './Resource'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,2 @@
+// Export component format placeholder
+// export { default as Resource } from './Resource'

--- a/src/scenes/index.js
+++ b/src/scenes/index.js
@@ -1,0 +1,2 @@
+// Export component format placeholder
+// export { default as Resource } from './Resource'

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,2 @@
+// Export component format placeholder
+// export { default as Resource } from './Resource'


### PR DESCRIPTION
The export format was declared as a comment in:

- src/common/index.js
- src/components/index.js
- src/scenes/index.js
- src/services/index.js